### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/iso3_lookup/backend.py
+++ b/iso3_lookup/backend.py
@@ -1,5 +1,5 @@
 import requests
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 import pickle
 import os
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-fuzzywuzzy
-python-Levenshtein
+rapidfuzz
 requests

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     version="0.9.0",
     packages=find_packages(),
     entry_points={"console_scripts": ["iso3_tests.py = iso3_lookup.tests:run"]},
-    install_requires=["fuzzywuzzy", "python-Levenshtein", "requests"],
+    install_requires=["rapidfuzz", "requests"],
     author="Sam Watson",
     author_email="watson.sam95@gmail.com",
     description="Go from iso3 -> country name and visa versa",


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy